### PR TITLE
Avoid potential overhead of IsCurrent check when not inlining continuations

### DIFF
--- a/src/Tmds.LinuxAsync/AsyncEngine.cs
+++ b/src/Tmds.LinuxAsync/AsyncEngine.cs
@@ -19,7 +19,7 @@ namespace Tmds.LinuxAsync
                     Volatile.Read(ref _socketEngine) == null)
                 {
                     // Provide a default.
-                    var engine = new EPollAsyncEngine(threadCount: Environment.ProcessorCount, useLinuxAio: true);
+                    var engine = new EPollAsyncEngine(threadCount: Environment.ProcessorCount, useLinuxAio: true, batchOnPollThread: true);
                     if (Interlocked.CompareExchange(ref _socketEngine, engine, null) != null)
                     {
                         engine.Dispose();

--- a/src/Tmds.LinuxAsync/EPollAsyncEngine.EPollThread.cs
+++ b/src/Tmds.LinuxAsync/EPollAsyncEngine.EPollThread.cs
@@ -27,6 +27,7 @@ namespace Tmds.LinuxAsync
             private int _blockedState;
 
             internal AsyncExecutionQueue? ExecutionQueue => _asyncExecutionQueue;
+            public bool BatchOnPollThread { get; }
 
             public bool IsCurrentThread => object.ReferenceEquals(_thread, Thread.CurrentThread);
 
@@ -40,9 +41,10 @@ namespace Tmds.LinuxAsync
             private List<ScheduledAction> _scheduledActions;
             private List<ScheduledAction> _executingActions;
 
-            public EPollThread(bool useLinuxAio)
+            public EPollThread(bool useLinuxAio, bool batchOnPollThread)
             {
                 _asyncContexts = new Dictionary<int, EPollAsyncContext>();
+                BatchOnPollThread = batchOnPollThread;
 
                 CreateResources(useLinuxAio);
 

--- a/src/Tmds.LinuxAsync/EPollAsyncEngine.cs
+++ b/src/Tmds.LinuxAsync/EPollAsyncEngine.cs
@@ -9,12 +9,12 @@ namespace Tmds.LinuxAsync
         private readonly EPollThread[] _threads;
         private int _previousThreadIdx = -1;
 
-        public EPollAsyncEngine(int threadCount, bool useLinuxAio)
+        public EPollAsyncEngine(int threadCount, bool useLinuxAio, bool batchOnPollThread)
         {
             _threads = new EPollThread[threadCount];
             for (int i = 0; i < _threads.Length; i++)
             {
-                _threads[i] = new EPollThread(useLinuxAio);
+                _threads[i] = new EPollThread(useLinuxAio, batchOnPollThread);
             }
         }
 

--- a/test/web/Program.cs
+++ b/test/web/Program.cs
@@ -49,7 +49,9 @@ namespace web
             switch (commandLineOptions.SocketEngine)
             {
                 case SocketEngineType.EPoll:
-                    return new EPollAsyncEngine(threadCount: commandLineOptions.ThreadCount, useLinuxAio: commandLineOptions.UseAio.Value);
+                    return new EPollAsyncEngine(threadCount: commandLineOptions.ThreadCount,
+                        useLinuxAio: commandLineOptions.UseAio.Value,
+                        batchOnPollThread: !commandLineOptions.DispatchContinuations.Value);
                 case SocketEngineType.IOUring:
                     return new IOUringAsyncEngine(threadCount: commandLineOptions.ThreadCount);
                 default:


### PR DESCRIPTION
When implementing https://github.com/tmds/Tmds.LinuxAsync/pull/37
a check was added to know whether the operation was being started on the poll thread.
I don't know if this check affects benchmark results when operations can never be started on the poll thread because completions are dispatched to the threadpool (`c=true`).
With this change, the ThreadStatic check for the poll thread is no longer performed when `c=true`.