### PR TITLE
Inline HandleEvents

### DIFF
--- a/src/Tmds.LinuxAsync/EPollAsyncEngine.EPollAsyncContext.cs
+++ b/src/Tmds.LinuxAsync/EPollAsyncEngine.EPollAsyncContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static Tmds.Linux.LibC;
 
@@ -111,6 +112,7 @@ namespace Tmds.LinuxAsync
                 }
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void HandleEvents(int events)
             {
                 if ((events & EPOLLERR) != 0)


### PR DESCRIPTION
On epoll thread, HandleEvents is 29,2% Inc, and 2,9% Exc.

@adamsitnik I wonder if that makes it a candidate for inlining.