### PR TITLE
Support using ThreadPool as output writer scheduler

### DIFF
--- a/src/Tmds.LinuxAsync.Transport/Internal/SocketConnection.cs
+++ b/src/Tmds.LinuxAsync.Transport/Internal/SocketConnection.cs
@@ -78,6 +78,7 @@ namespace Tmds.LinuxAsync.Transport.Internal
                 OutputWriterScheduler.Inline => PipeScheduler.Inline,
                 OutputWriterScheduler.IOQueue => scheduler,
                 OutputWriterScheduler.IOThread => _socket.IOThreadScheduler,
+                OutputWriterScheduler.ThreadPool => PipeScheduler.ThreadPool,
                 _ => throw new IndexOutOfRangeException()
             };
 

--- a/src/Tmds.LinuxAsync.Transport/SocketTransportOptions.cs
+++ b/src/Tmds.LinuxAsync.Transport/SocketTransportOptions.cs
@@ -11,7 +11,8 @@ namespace Tmds.LinuxAsync.Transport
     {
         IOQueue,
         Inline,
-        IOThread
+        IOThread,
+        ThreadPool
     }
 
     public class SocketTransportOptions

--- a/test/web/ConsoleLineArgumentsParser.cs
+++ b/test/web/ConsoleLineArgumentsParser.cs
@@ -41,7 +41,7 @@ namespace web
         [Option('w', "wait-for-ready", Required = false, Default = true, HelpText = "Don't allocate memory for idle connections")]
         public bool? DontAllocateMemoryForIdleConnections { get; set; }
 
-        [Option('o', "output-writer-scheduler", Required = false, Default = OutputWriterScheduler.IOQueue, HelpText = "IOQueue/Inline/IOThread")]
+        [Option('o', "output-writer-scheduler", Required = false, Default = OutputWriterScheduler.IOQueue, HelpText = "IOQueue/Inline/IOThread/ThreadPool")]
         public OutputWriterScheduler OutputWriterScheduler { get; set; }
 
         [Option('i', "inline-app", Required = false, Default = false, HelpText = "Application code is non blocking")]


### PR DESCRIPTION
This adds an additional option for the output writer scheduler.

We've already experimented using `Inline` and `IoThread`.

These have some limitations:
`Inline` is unable to batch multiple writes to a pipe. This will definitely affect pipelined plaintext benchmark. But also in non-pipelined cases, it is an issue because the pipe reader can't distinguish between the writer writing, or flushing. With inline scheduler this means we perform a send syscall even for intermediates writes.
`IoThread` requires `Socket` to expose a `PipeScheduler` in some form.

This adds the option to use `ThreadPool` as the scheduler.
Compared to `Inline` there is scheduling overhead, but there is the advantage of batching multiple writes.
Compared to `IoQueue` it may be nicer for the `ThreadPool` implementation.
Compared to `IoThread` it is unable to batch the operations, because they don't occur on the io thread.

cc @antonfirsov @adamsitnik 