### PR TITLE
Refactor: split AsyncOperation.TryExecute

### DIFF
--- a/src/Tmds.LinuxAsync/AsyncAcceptOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncAcceptOperation.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks.Sources;
+using static Tmds.Linux.LibC;
 
 namespace Tmds.LinuxAsync
 {
@@ -170,6 +171,12 @@ namespace Tmds.LinuxAsync
 
         private AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
         {
+            if (asyncResult.Errno == ECANCELED)
+            {
+                SocketError = SocketError.OperationAborted;
+                return AsyncExecutionResult.Cancelled;
+            }
+
             // poll says we're ready
             bool finished = TryExecuteSync();
             return finished ? AsyncExecutionResult.Finished : AsyncExecutionResult.WaitForPoll;

--- a/src/Tmds.LinuxAsync/AsyncAcceptOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncAcceptOperation.cs
@@ -146,29 +146,7 @@ namespace Tmds.LinuxAsync
             }
         }
 
-        public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult asyncResult, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
-        {
-            AsyncExecutionResult result = HandleAsyncResult(asyncResult);
-
-            if (result == AsyncExecutionResult.Finished)
-            {
-                return AsyncExecutionResult.Finished;
-            }
-
-            if (result == AsyncExecutionResult.Cancelled || IsCancellationRequested)
-            {
-                return AsyncExecutionResult.Cancelled;
-            }
-
-            if (result == AsyncExecutionResult.WaitForPoll && executionQueue?.SupportsPolling != true)
-            {
-                return AsyncExecutionResult.WaitForPoll;
-            }
-
-            return TryExecuteAsync(triggeredByPoll: false, executionQueue, callback, state, data);
-        }
-
-        private AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
+        public override AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
         {
             if (asyncResult.Errno == ECANCELED)
             {

--- a/src/Tmds.LinuxAsync/AsyncAcceptOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncAcceptOperation.cs
@@ -155,9 +155,8 @@ namespace Tmds.LinuxAsync
                 return AsyncExecutionResult.Finished;
             }
 
-            if (IsCancellationRequested)
+            if (result == AsyncExecutionResult.Cancelled || IsCancellationRequested)
             {
-                SocketError = SocketError.OperationAborted;
                 return AsyncExecutionResult.Cancelled;
             }
 
@@ -173,7 +172,6 @@ namespace Tmds.LinuxAsync
         {
             if (asyncResult.Errno == ECANCELED)
             {
-                SocketError = SocketError.OperationAborted;
                 return AsyncExecutionResult.Cancelled;
             }
 

--- a/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
@@ -168,29 +168,7 @@ namespace Tmds.LinuxAsync
             }
         }
 
-        public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult asyncResult, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
-        {
-            AsyncExecutionResult result = HandleAsyncResult(asyncResult);
-
-            if (result == AsyncExecutionResult.Finished)
-            {
-                return AsyncExecutionResult.Finished;
-            }
-
-            if (result == AsyncExecutionResult.Cancelled || IsCancellationRequested)
-            {
-                return AsyncExecutionResult.Cancelled;
-            }
-
-            if (result == AsyncExecutionResult.WaitForPoll && executionQueue?.SupportsPolling != true)
-            {
-                return AsyncExecutionResult.WaitForPoll;
-            }
-
-            return TryExecuteAsync(triggeredByPoll: false, executionQueue, callback, state, data);
-        }
-
-        private AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
+        public override AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
         {
             if (asyncResult.Errno == ECANCELED)
             {

--- a/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
@@ -116,59 +116,85 @@ namespace Tmds.LinuxAsync
         {
             Socket = socket;
             EndPoint = endPoint;
+
+            if (endPoint.GetType() != typeof(IPEndPoint))
+            {
+                throw new NotSupportedException();
+            }
         }
 
         public override bool IsReadNotWrite => false;
 
-        public override AsyncExecutionResult TryExecute(bool triggeredByPoll, bool isCancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult asyncResult)
+        public override bool TryExecuteSync()
         {
             Socket socket = Socket!;
-            IPEndPoint? ipEndPoint = EndPoint as IPEndPoint;
-
-            if (ipEndPoint == null)
+            IPEndPoint ipEndPoint = (IPEndPoint)EndPoint!;
+            SocketError socketError = SocketPal.Connect(socket.SafeHandle, ipEndPoint);
+            if (socketError == SocketError.InProgress)
             {
-                ThrowHelper.ThrowInvalidOperationException();
+                return false;
             }
+            SocketError = socketError;
+            return true;
+        }
 
-            // When there is a pollable executionQueue, use it to poll, and then try the operation.
-            bool hasPollableExecutionQueue = executionQueue?.SupportsPolling == true;
-            bool trySync = !hasPollableExecutionQueue && !asyncOnly;
-            if (trySync || asyncResult.HasResult)
+        public override AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+        {
+            if (executionQueue != null && executionQueue.SupportsPolling == true)
             {
-                SocketError socketError;
-                if (!_connectCalled)
-                {
-                    socketError = SocketPal.Connect(socket.SafeHandle, ipEndPoint);
-                    _connectCalled = true;
-                }
-                else
-                {
-                    // TODO: read SOL_SOCKET, SO_ERROR to get errorcode...
-                    socketError = SocketError.Success;
-                }
-                if (socketError != SocketError.InProgress)
-                {
-                    SocketError = socketError;
-                    return AsyncExecutionResult.Finished;
-                }
-            }
-
-            if (isCancellationRequested)
-            {
-                SocketError = SocketError.OperationAborted;
-                return AsyncExecutionResult.Cancelled;
-            }
-
-            // poll
-            if (hasPollableExecutionQueue)
-            {
+                Socket socket = Socket!;
                 executionQueue!.AddPollOut(socket.SafeHandle, callback!, state, data);
                 return AsyncExecutionResult.Executing;
             }
             else
             {
+                if (!_connectCalled)
+                {
+                    bool finished = TryExecuteSync();
+                    return finished ? AsyncExecutionResult.Finished : AsyncExecutionResult.WaitForPoll;
+                }
+                else
+                {
+                    if (triggeredByPoll)
+                    {
+                        // TODO: read SOL_SOCKET, SO_ERROR to get errorcode...
+                        SocketError = SocketError.Success;
+                        return AsyncExecutionResult.Finished;
+                    }
+                    return AsyncExecutionResult.WaitForPoll;
+                }
+            }
+        }
+
+        public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult asyncResult, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+        {
+            AsyncExecutionResult result = HandleAsyncResult(asyncResult);
+
+            if (result == AsyncExecutionResult.Finished)
+            {
+                return AsyncExecutionResult.Finished;
+            }
+
+            if (IsCancellationRequested)
+            {
+                SocketError = SocketError.OperationAborted;
+                return AsyncExecutionResult.Cancelled;
+            }
+
+            if (result == AsyncExecutionResult.WaitForPoll && executionQueue?.SupportsPolling != true)
+            {
                 return AsyncExecutionResult.WaitForPoll;
             }
+
+            return TryExecuteAsync(triggeredByPoll: false, executionQueue, callback, state, data);
+        }
+
+        private AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
+        {
+            // poll says we're ready
+            // TODO: read SOL_SOCKET, SO_ERROR to get errorcode...
+            SocketError = SocketError.Success;
+            return AsyncExecutionResult.Finished;
         }
 
         protected void ResetOperationState()

--- a/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
@@ -151,6 +151,7 @@ namespace Tmds.LinuxAsync
             {
                 if (!_connectCalled)
                 {
+                    _connectCalled = true;
                     bool finished = TryExecuteSync();
                     return finished ? AsyncExecutionResult.Finished : AsyncExecutionResult.WaitForPoll;
                 }

--- a/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
@@ -177,9 +177,8 @@ namespace Tmds.LinuxAsync
                 return AsyncExecutionResult.Finished;
             }
 
-            if (IsCancellationRequested)
+            if (result == AsyncExecutionResult.Cancelled || IsCancellationRequested)
             {
-                SocketError = SocketError.OperationAborted;
                 return AsyncExecutionResult.Cancelled;
             }
 
@@ -195,7 +194,6 @@ namespace Tmds.LinuxAsync
         {
             if (asyncResult.Errno == ECANCELED)
             {
-                SocketError = SocketError.OperationAborted;
                 return AsyncExecutionResult.Cancelled;
             }
 

--- a/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks.Sources;
+using static Tmds.Linux.LibC;
 
 namespace Tmds.LinuxAsync
 {
@@ -191,6 +192,12 @@ namespace Tmds.LinuxAsync
 
         private AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
         {
+            if (asyncResult.Errno == ECANCELED)
+            {
+                SocketError = SocketError.OperationAborted;
+                return AsyncExecutionResult.Cancelled;
+            }
+
             // poll says we're ready
             // TODO: read SOL_SOCKET, SO_ERROR to get errorcode...
             SocketError = SocketError.Success;

--- a/src/Tmds.LinuxAsync/AsyncOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncOperation.cs
@@ -62,9 +62,10 @@ namespace Tmds.LinuxAsync
         public abstract AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data);
 
         // Handles the result from the ExecutionQueue,
-        // and continues executing the operation it has not finished.
-        // Return value is the same as from TryExecuteAsync.
-        public abstract AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult result, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data);
+        // Returns Executing if the operation should be tried immediately,
+        // WaitForPoll if the operation should be tried when the handle is ready.
+        // Finished/Cancelled when the operation is finished.
+        public abstract AsyncExecutionResult HandleAsyncResult(AsyncOperationResult result);
 
         // Requests operation to be cancelled.
         public void TryCancelAndComplete(OperationStatus status = OperationStatus.None)

--- a/src/Tmds.LinuxAsync/AsyncOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncOperation.cs
@@ -54,26 +54,17 @@ namespace Tmds.LinuxAsync
         // Try to execute the operation. Returns true when done, false it should be tried again.
         public abstract bool TryExecuteSync();
 
+        // Asynchronously executes the operation on the io-thread.
+        // The AsyncExecutionQueue when provided may be used to batch operations.
+        // When the operation can make use of the executionQueue, AsyncExecutionResult.Executing is returned.
+        // When the operation cannot make use of the queue, the operation is attempted synchronously
+        // and WaitForPoll/Finished is returned.
         public abstract AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data);
 
+        // Handles the result from the ExecutionQueue,
+        // and continues executing the operation it has not finished.
+        // Return value is the same as from TryExecuteAsync.
         public abstract AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult result, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data);
-
-        // Continues execution of this operation.
-        // When the operation is finished, AsyncExecutionResult.Finished is returned.
-        // The executionQueue, when not null, can be used to batch operations.
-        //   The callback, state, and data arguments must be passed on to the executionQueue.
-        // When the executionQueue is used, AsyncExecutionResult.Executing is returned.
-        // When the batched operations completes, the method is called again and 'result' has a value.
-        // The execution queue may or may not support poll operations (ExecutionQueue.SupportsPolling).
-        // In case there is no execution queue, or the queue does not support polling, the method
-        // can return WaitForPoll. The method will be called again when poll indicates the handle is ready,
-        // (and triggeredByPoll is true).
-        // When asyncOnly is set, the execution queue must be used. If it cannot be used, WaitForPoll
-        // must be returned.
-        // When cancellationRequested is set, the operation must finish with
-        //   AsyncExecutionResult.Finished when the operation completed using 'result'; and
-        //   AsyncOperationResult.Cancelled otherwise.
-        // public abstract AsyncExecutionResult TryExecute(bool triggeredByPoll, bool cancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult result);
 
         // Requests operation to be cancelled.
         public void TryCancelAndComplete(OperationStatus status = OperationStatus.None)

--- a/src/Tmds.LinuxAsync/AsyncOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncOperation.cs
@@ -52,8 +52,11 @@ namespace Tmds.LinuxAsync
         public abstract void Complete();
 
         // Try to execute the operation. Returns true when done, false it should be tried again.
-        public bool TryExecuteSync()
-            => TryExecute(triggeredByPoll: false, cancellationRequested: false, asyncOnly: false, executionQueue: null, callback: null, state: null, data: 0, AsyncOperationResult.NoResult) == AsyncExecutionResult.Finished;
+        public abstract bool TryExecuteSync();
+
+        public abstract AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data);
+
+        public abstract AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult result, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data);
 
         // Continues execution of this operation.
         // When the operation is finished, AsyncExecutionResult.Finished is returned.
@@ -70,7 +73,7 @@ namespace Tmds.LinuxAsync
         // When cancellationRequested is set, the operation must finish with
         //   AsyncExecutionResult.Finished when the operation completed using 'result'; and
         //   AsyncOperationResult.Cancelled otherwise.
-        public abstract AsyncExecutionResult TryExecute(bool triggeredByPoll, bool cancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult result);
+        // public abstract AsyncExecutionResult TryExecute(bool triggeredByPoll, bool cancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult result);
 
         // Requests operation to be cancelled.
         public void TryCancelAndComplete(OperationStatus status = OperationStatus.None)

--- a/src/Tmds.LinuxAsync/AsyncOperationQueueBase.cs
+++ b/src/Tmds.LinuxAsync/AsyncOperationQueueBase.cs
@@ -217,7 +217,7 @@ namespace Tmds.LinuxAsync
                 => throw new System.InvalidOperationException();
             public override AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data)
                 => throw new System.InvalidOperationException();
-            public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult result, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+            public override AsyncExecutionResult HandleAsyncResult(AsyncOperationResult result)
                 => throw new System.InvalidOperationException();
         }
 
@@ -231,7 +231,7 @@ namespace Tmds.LinuxAsync
                 => throw new System.InvalidOperationException();
             public override AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data)
                 => throw new System.InvalidOperationException();
-            public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult result, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+            public override AsyncExecutionResult HandleAsyncResult(AsyncOperationResult result)
                 => throw new System.InvalidOperationException();
         }
 

--- a/src/Tmds.LinuxAsync/AsyncOperationQueueBase.cs
+++ b/src/Tmds.LinuxAsync/AsyncOperationQueueBase.cs
@@ -213,7 +213,11 @@ namespace Tmds.LinuxAsync
                 => throw new System.InvalidOperationException();
             public override void Complete()
                 => throw new System.InvalidOperationException();
-            public override AsyncExecutionResult TryExecute(bool triggeredByPoll, bool cancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult result)
+            public override bool TryExecuteSync()
+                => throw new System.InvalidOperationException();
+            public override AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+                => throw new System.InvalidOperationException();
+            public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult result, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
                 => throw new System.InvalidOperationException();
         }
 
@@ -223,7 +227,11 @@ namespace Tmds.LinuxAsync
                 => throw new System.InvalidOperationException();
             public override void Complete()
                 => throw new System.InvalidOperationException();
-            public override AsyncExecutionResult TryExecute(bool triggeredByPoll, bool cancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult result)
+            public override bool TryExecuteSync()
+                => throw new System.InvalidOperationException();
+            public override AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+                => throw new System.InvalidOperationException();
+            public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult result, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
                 => throw new System.InvalidOperationException();
         }
 

--- a/src/Tmds.LinuxAsync/AsyncReceiveOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncReceiveOperation.cs
@@ -163,29 +163,7 @@ namespace Tmds.LinuxAsync
             }
         }
 
-        public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult asyncResult, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
-        {
-            AsyncExecutionResult result = HandleAsyncResult(asyncResult);
-
-            if (result == AsyncExecutionResult.Finished)
-            {
-                return AsyncExecutionResult.Finished;
-            }
-
-            if (result == AsyncExecutionResult.Cancelled || IsCancellationRequested)
-            {
-                return AsyncExecutionResult.Cancelled;
-            }
-
-            if (result == AsyncExecutionResult.WaitForPoll && executionQueue?.SupportsPolling != true)
-            {
-                return AsyncExecutionResult.WaitForPoll;
-            }
-
-            return TryExecuteAsync(triggeredByPoll: false, executionQueue, callback, state, data);
-        }
-
-        private AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
+        public override AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
         {
             if (asyncResult.IsError)
             {

--- a/src/Tmds.LinuxAsync/AsyncReceiveOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncReceiveOperation.cs
@@ -172,9 +172,8 @@ namespace Tmds.LinuxAsync
                 return AsyncExecutionResult.Finished;
             }
 
-            if (IsCancellationRequested)
+            if (result == AsyncExecutionResult.Cancelled || IsCancellationRequested)
             {
-                SocketError = SocketError.OperationAborted;
                 return AsyncExecutionResult.Cancelled;
             }
 
@@ -196,7 +195,6 @@ namespace Tmds.LinuxAsync
                 }
                 else if (asyncResult.Errno == ECANCELED)
                 {
-                    SocketError = SocketError.OperationAborted;
                     return AsyncExecutionResult.Cancelled;
                 }
                 else if (asyncResult.Errno == EAGAIN)

--- a/src/Tmds.LinuxAsync/AsyncReceiveOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncReceiveOperation.cs
@@ -165,30 +165,27 @@ namespace Tmds.LinuxAsync
 
         public override AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
         {
-            if (asyncResult.IsError)
-            {
-                if (asyncResult.Errno == EINTR)
-                {
-                    return AsyncExecutionResult.Executing;
-                }
-                else if (asyncResult.Errno == ECANCELED)
-                {
-                    return AsyncExecutionResult.Cancelled;
-                }
-                else if (asyncResult.Errno == EAGAIN)
-                {
-                    return AsyncExecutionResult.WaitForPoll;
-                }
-                else
-                {
-                    SocketError = SocketPal.GetSocketErrorForErrno(asyncResult.Errno);
-                    return AsyncExecutionResult.Finished;
-                }
-            }
-            else
+            if (asyncResult.Errno == 0)
             {
                 BytesTransferred = asyncResult.IntValue;
                 SocketError = SocketError.Success;
+                return AsyncExecutionResult.Finished;
+            }
+            else if (asyncResult.Errno == EINTR)
+            {
+                return AsyncExecutionResult.Executing;
+            }
+            else if (asyncResult.Errno == ECANCELED)
+            {
+                return AsyncExecutionResult.Cancelled;
+            }
+            else if (asyncResult.Errno == EAGAIN)
+            {
+                return AsyncExecutionResult.WaitForPoll;
+            }
+            else
+            {
+                SocketError = SocketPal.GetSocketErrorForErrno(asyncResult.Errno);
                 return AsyncExecutionResult.Finished;
             }
         }

--- a/src/Tmds.LinuxAsync/AsyncSendOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncSendOperation.cs
@@ -246,27 +246,7 @@ namespace Tmds.LinuxAsync
 
         public override AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
         {
-            if (asyncResult.IsError)
-            {
-                if (asyncResult.Errno == EINTR)
-                {
-                    return AsyncExecutionResult.Executing;
-                }
-                else if (asyncResult.Errno == ECANCELED)
-                {
-                    return AsyncExecutionResult.Cancelled;
-                }
-                else if (asyncResult.Errno == EAGAIN)
-                {
-                    return AsyncExecutionResult.WaitForPoll;
-                }
-                else
-                {
-                    SocketError = SocketPal.GetSocketErrorForErrno(asyncResult.Errno);
-                    return AsyncExecutionResult.Finished;
-                }
-            }
-            else
+            if (asyncResult.Errno == 0)
             {
                 BytesTransferred += asyncResult.IntValue;
 
@@ -295,6 +275,23 @@ namespace Tmds.LinuxAsync
                 }
 
                 return AsyncExecutionResult.Executing;
+            }
+            else if (asyncResult.Errno == EINTR)
+            {
+                return AsyncExecutionResult.Executing;
+            }
+            else if (asyncResult.Errno == ECANCELED)
+            {
+                return AsyncExecutionResult.Cancelled;
+            }
+            else if (asyncResult.Errno == EAGAIN)
+            {
+                return AsyncExecutionResult.WaitForPoll;
+            }
+            else
+            {
+                SocketError = SocketPal.GetSocketErrorForErrno(asyncResult.Errno);
+                return AsyncExecutionResult.Finished;
             }
         }
 

--- a/src/Tmds.LinuxAsync/AsyncSendOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncSendOperation.cs
@@ -112,6 +112,7 @@ namespace Tmds.LinuxAsync
         private Memory<byte> MemoryBuffer;
         private IList<ArraySegment<byte>>? BufferList;
         private int _bufferIndex;
+        private int _bufferOffset;
         protected SocketError SocketError;
         protected int BytesTransferred;
 
@@ -124,131 +125,201 @@ namespace Tmds.LinuxAsync
 
         public override bool IsReadNotWrite => false;
 
-        public override AsyncExecutionResult TryExecute(bool triggeredByPoll, bool isCancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult asyncResult)
+        public override bool TryExecuteSync()
         {
             IList<ArraySegment<byte>>? bufferList = BufferList;
 
             if (bufferList == null)
             {
-                return SendSingleBuffer(MemoryBuffer, isCancellationRequested, asyncOnly, executionQueue, callback, state, data, asyncResult);
+                return TryExecuteSingleBufferSync(MemoryBuffer);
             }
             else
             {
-                return SendMultipleBuffers(bufferList, isCancellationRequested, asyncOnly, executionQueue, callback, state, data, asyncResult);
+                return TryExecuteMultipleBuffersSync(bufferList);
             }
         }
 
-        private unsafe AsyncExecutionResult SendMultipleBuffers(IList<ArraySegment<byte>> buffers, bool isCancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult asyncResult)
+        private bool TryExecuteSingleBufferSync(Memory<byte> memory)
         {
-            // TODO: really support multi-buffer sends...
+            Socket socket = Socket!;
+            (SocketError socketError, int bytesTransferred) = SendMemory(socket, memory);
+            BytesTransferred += bytesTransferred;
+            if (socketError == SocketError.WouldBlock)
+            {
+                return false;
+            }
+            SocketError = socketError;
+            return true;
+        }
+
+        private static (SocketError socketError, int bytesTransferred) SendMemory(Socket socket, Memory<byte> memory)
+        {
+            int bytesTransferredTotal = 0;
+            while (true)
+            {
+                Memory<byte> remaining = memory.Slice(bytesTransferredTotal);
+                (SocketError socketError, int bytesTransferred) = SocketPal.Send(socket.SafeHandle, remaining);
+                bytesTransferredTotal += bytesTransferred;
+                if (socketError == SocketError.Success)
+                {
+                    if (bytesTransferredTotal != memory.Length && bytesTransferred != 0)
+                    {
+                        continue;
+                    }
+                }
+                return (socketError, bytesTransferredTotal);
+            }
+        }
+
+        private bool TryExecuteMultipleBuffersSync(IList<ArraySegment<byte>> buffers)
+        {
+            Socket socket = Socket!;
             for (; _bufferIndex < buffers.Count; _bufferIndex++)
             {
-                AsyncExecutionResult bufferSendResult = SendSingleBuffer(buffers[_bufferIndex], isCancellationRequested, asyncOnly, executionQueue, callback, state, data, asyncResult);
-                if (bufferSendResult == AsyncExecutionResult.WaitForPoll || bufferSendResult == AsyncExecutionResult.Executing)
+                Memory<byte> memory = buffers[_bufferIndex].Slice(_bufferOffset);
+                (SocketError socketError, int bytesTransferred) = SendMemory(socket, memory);
+                _bufferOffset += bytesTransferred;
+                BytesTransferred += bytesTransferred;
+                if (socketError == SocketError.WouldBlock)
                 {
-                    return bufferSendResult;
+                    return false;
                 }
-                if (SocketError != SocketError.Success)
+                else if (socketError == SocketError.Success && bytesTransferred == memory.Length)
                 {
-                    break;
-                }
-                BytesTransferred = 0; // TODO... not really correct
-            }
-            return AsyncExecutionResult.Finished;
-        }
-
-        private AsyncExecutionResult SendSingleBuffer(Memory<byte> memory, bool isCancellationRequested, bool asyncOnly, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data, AsyncOperationResult asyncResult)
-        {
-            SocketError socketError = SocketError.SocketError;
-            AsyncExecutionResult result = AsyncExecutionResult.Executing;
-            if (asyncResult.HasResult)
-            {
-                if (asyncResult.IsError)
-                {
-                    if (asyncResult.Errno == EINTR)
-                    {
-                        result = AsyncExecutionResult.Executing;
-                    }
-                    else if (asyncResult.Errno == EAGAIN)
-                    {
-                        result = AsyncExecutionResult.WaitForPoll;
-                    }
-                    else
-                    {
-                        socketError = SocketPal.GetSocketErrorForErrno(asyncResult.Errno);
-                        result = AsyncExecutionResult.Finished;
-                    }
+                    _bufferOffset = 0;
+                    continue;
                 }
                 else
                 {
-                    BytesTransferred += asyncResult.IntValue;
-                    if (BytesTransferred == memory.Length)
-                    {
-                        socketError = SocketError.Success;
-                        result = AsyncExecutionResult.Finished;
-                    }
+                    SocketError = socketError;
+                    return true;
                 }
             }
+            SocketError = SocketError.Success;
+            return true;
+        }
 
-            if (isCancellationRequested && result != AsyncExecutionResult.Finished)
+        public override AsyncExecutionResult TryExecuteAsync(bool triggeredByPoll, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+        {
+            IList<ArraySegment<byte>>? bufferList = BufferList;
+
+            if (bufferList == null)
+            {
+                return TryExecuteSingleBufferAsync(MemoryBuffer.Slice(BytesTransferred), executionQueue, callback, state, data);
+            }
+            else
+            {
+                return TryExecuteMultipleBuffersAsync(bufferList, executionQueue, callback, state, data);
+            }
+        }
+
+        private AsyncExecutionResult TryExecuteMultipleBuffersAsync(IList<ArraySegment<byte>> buffers, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+        {
+            if (executionQueue != null)
+            {
+                Socket socket = Socket!;
+                Memory<byte> memory = buffers[_bufferIndex].Slice(_bufferOffset);
+                executionQueue.AddWrite(socket.SafeHandle, memory, callback!, state, data);
+                return AsyncExecutionResult.Executing;
+            }
+            else
+            {
+                bool finished = TryExecuteMultipleBuffersSync(buffers);
+                return finished ? AsyncExecutionResult.Finished : AsyncExecutionResult.WaitForPoll;
+            }
+        }
+
+        private AsyncExecutionResult TryExecuteSingleBufferAsync(Memory<byte> memory, AsyncExecutionQueue? executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+        {
+            if (executionQueue != null)
+            {
+                Socket socket = Socket!;
+                executionQueue.AddWrite(socket.SafeHandle, memory, callback!, state, data);
+                return AsyncExecutionResult.Executing;
+            }
+            else
+            {
+                bool finished = TryExecuteSingleBufferSync(memory);
+                return finished ? AsyncExecutionResult.Finished : AsyncExecutionResult.WaitForPoll;
+            }
+        }
+
+        public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult asyncResult, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
+        {
+            AsyncExecutionResult result = HandleAsyncResult(asyncResult);
+
+            if (result == AsyncExecutionResult.Finished)
+            {
+                return AsyncExecutionResult.Finished;
+            }
+
+            if (IsCancellationRequested)
             {
                 SocketError = SocketError.OperationAborted;
                 return AsyncExecutionResult.Cancelled;
             }
 
-            // When there is a pollable executionQueue, use it to poll, and then try the operation.
-            if (result == AsyncExecutionResult.Executing ||
-                (result == AsyncExecutionResult.WaitForPoll && executionQueue?.SupportsPolling == true))
+            if (result == AsyncExecutionResult.WaitForPoll && executionQueue?.SupportsPolling != true)
             {
-                Socket socket = Socket!;
-                if (socket == null)
-                {
-                    ThrowHelper.ThrowInvalidOperationException();
-                }
+                return AsyncExecutionResult.WaitForPoll;
+            }
 
-                if (executionQueue != null)
+            return TryExecuteAsync(triggeredByPoll: false, executionQueue, callback, state, data);
+        }
+
+        private AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
+        {
+            if (asyncResult.IsError)
+            {
+                if (asyncResult.Errno == EINTR)
                 {
-                    Memory<byte> remaining = memory.Slice(BytesTransferred);
-                    executionQueue.AddWrite(socket.SafeHandle, remaining, callback!, state, data);
-                    result = AsyncExecutionResult.Executing;
+                    return AsyncExecutionResult.Executing;
                 }
-                else if (result == AsyncExecutionResult.Executing)
+                else if (asyncResult.Errno == ECANCELED)
                 {
-                    if (asyncOnly)
+                    SocketError = SocketError.OperationAborted;
+                    return AsyncExecutionResult.Cancelled;
+                }
+                else if (asyncResult.Errno == EAGAIN)
+                {
+                    return AsyncExecutionResult.WaitForPoll;
+                }
+                else
+                {
+                    SocketError = SocketPal.GetSocketErrorForErrno(asyncResult.Errno);
+                    return AsyncExecutionResult.Finished;
+                }
+            }
+            else
+            {
+                BytesTransferred += asyncResult.IntValue;
+
+                IList<ArraySegment<byte>>? bufferList = BufferList;
+                if (bufferList == null)
+                {
+                    if (BytesTransferred == MemoryBuffer.Length)
                     {
-                        result = AsyncExecutionResult.WaitForPoll;
+                        SocketError = SocketError.Success;
+                        return AsyncExecutionResult.Finished;
                     }
-                    else
+                }
+                else
+                {
+                    _bufferOffset += asyncResult.IntValue;
+                    if (_bufferOffset == bufferList[_bufferIndex].Count)
                     {
-                        while (true)
+                        _bufferOffset = 0;
+                        _bufferIndex++;
+                        if (_bufferIndex == bufferList.Count)
                         {
-                            Memory<byte> remaining = memory.Slice(BytesTransferred);
-                            int bytesTransferred;
-                            (socketError, bytesTransferred) = SocketPal.Send(socket.SafeHandle, remaining);
-                            if (socketError == SocketError.Success)
-                            {
-                                BytesTransferred += bytesTransferred;
-                                if (BytesTransferred == memory.Length || bytesTransferred == 0)
-                                {
-                                    break;
-                                }
-                            }
-                            else
-                            {
-                                break;
-                            }
+                            SocketError = SocketError.Success;
+                            return AsyncExecutionResult.Finished;
                         }
-                        result = socketError == SocketError.WouldBlock ? AsyncExecutionResult.WaitForPoll : AsyncExecutionResult.Finished;
                     }
                 }
-            }
 
-            if (result == AsyncExecutionResult.Finished)
-            {
-                SocketError = socketError;
+                return AsyncExecutionResult.Executing;
             }
-
-            return result;
         }
 
         protected void ResetOperationState()
@@ -257,6 +328,7 @@ namespace Tmds.LinuxAsync
             MemoryBuffer = default;
             BufferList = null;
             _bufferIndex = 0;
+            _bufferOffset = 0;
             SocketError = SocketError.SocketError;
             BytesTransferred = 0;
         }

--- a/src/Tmds.LinuxAsync/AsyncSendOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncSendOperation.cs
@@ -253,9 +253,8 @@ namespace Tmds.LinuxAsync
                 return AsyncExecutionResult.Finished;
             }
 
-            if (IsCancellationRequested)
+            if (result == AsyncExecutionResult.Cancelled || IsCancellationRequested)
             {
-                SocketError = SocketError.OperationAborted;
                 return AsyncExecutionResult.Cancelled;
             }
 
@@ -277,7 +276,6 @@ namespace Tmds.LinuxAsync
                 }
                 else if (asyncResult.Errno == ECANCELED)
                 {
-                    SocketError = SocketError.OperationAborted;
                     return AsyncExecutionResult.Cancelled;
                 }
                 else if (asyncResult.Errno == EAGAIN)

--- a/src/Tmds.LinuxAsync/AsyncSendOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncSendOperation.cs
@@ -244,29 +244,7 @@ namespace Tmds.LinuxAsync
             }
         }
 
-        public override AsyncExecutionResult HandleAsyncResultAndContinue(AsyncOperationResult asyncResult, AsyncExecutionQueue executionQueue, AsyncExecutionCallback? callback, object? state, int data)
-        {
-            AsyncExecutionResult result = HandleAsyncResult(asyncResult);
-
-            if (result == AsyncExecutionResult.Finished)
-            {
-                return AsyncExecutionResult.Finished;
-            }
-
-            if (result == AsyncExecutionResult.Cancelled || IsCancellationRequested)
-            {
-                return AsyncExecutionResult.Cancelled;
-            }
-
-            if (result == AsyncExecutionResult.WaitForPoll && executionQueue?.SupportsPolling != true)
-            {
-                return AsyncExecutionResult.WaitForPoll;
-            }
-
-            return TryExecuteAsync(triggeredByPoll: false, executionQueue, callback, state, data);
-        }
-
-        private AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
+        public override AsyncExecutionResult HandleAsyncResult(AsyncOperationResult asyncResult)
         {
             if (asyncResult.IsError)
             {

--- a/src/Tmds.LinuxAsync/AwaitableSocketOperationCore.cs
+++ b/src/Tmds.LinuxAsync/AwaitableSocketOperationCore.cs
@@ -81,6 +81,11 @@ namespace Tmds.LinuxAsync
                     {
                         throw new OperationCanceledException();
                     }
+                    bool cancelled = (_status & OperationStatus.Cancelled) != 0;
+                    if (cancelled)
+                    {
+                        _socketError = SocketError.OperationAborted;
+                    }
                     bool cancelledByTimeout = (_status & OperationStatus.CancelledByTimeout) != 0;
                     if (cancelledByTimeout)
                     {

--- a/src/Tmds.LinuxAsync/EPollAsyncEngine.Queue.cs
+++ b/src/Tmds.LinuxAsync/EPollAsyncEngine.Queue.cs
@@ -69,12 +69,10 @@ namespace Tmds.LinuxAsync
             {
                 AsyncOperation? op = _executingOperation!;
 
-                bool cancellationRequested = op.IsCancellationRequested;
-
-                AsyncExecutionResult result = op.TryExecute(triggeredByPoll: false, cancellationRequested, asyncOnly: false, _thread.ExecutionQueue,
+                AsyncExecutionResult result = op.HandleAsyncResultAndContinue(aResult, _thread.ExecutionQueue!,
                                                     (AsyncOperationResult aResult, object? state, int data)
                                                         => ((Queue)state!).HandleAsyncResult(aResult)
-                                                    , state: this, data: 0, aResult);
+                                                    , state: this, data: 0);
 
                 if (result == AsyncExecutionResult.Executing)
                 {
@@ -150,10 +148,10 @@ namespace Tmds.LinuxAsync
                         op = QueueGetFirst();
                     }
 
-                    AsyncExecutionResult result = op.TryExecute(triggeredByPoll, cancellationRequested: false, asyncOnly: false, _thread.ExecutionQueue,
+                    AsyncExecutionResult result = op.TryExecuteAsync(triggeredByPoll, _thread.ExecutionQueue,
                                                         (AsyncOperationResult aResult, object? state, int data)
                                                             => ((Queue)state!).HandleAsyncResult(aResult)
-                                                        , state: this, data: 0, AsyncOperationResult.NoResult);
+                                                        , state: this, data: 0);
 
                     if (result == AsyncExecutionResult.Executing)
                     {

--- a/src/Tmds.LinuxAsync/EPollAsyncEngine.Queue.cs
+++ b/src/Tmds.LinuxAsync/EPollAsyncEngine.Queue.cs
@@ -97,13 +97,16 @@ namespace Tmds.LinuxAsync
                 }
                 else // AsyncExecutionResult.WaitForPoll or Cancelled
                 {
-                    OperationStatus previous = op.CompareExchangeStatus(OperationStatus.Queued, OperationStatus.Executing);
-                    if (previous == OperationStatus.Executing)
+                    if (result == AsyncExecutionResult.WaitForPoll)
                     {
-                        // We've changed from executing to queued.
-                        return null;
+                        OperationStatus previous = op.CompareExchangeStatus(OperationStatus.Queued, OperationStatus.Executing);
+                        if (previous == OperationStatus.Executing)
+                        {
+                            // We've changed from executing to queued.
+                            return null;
+                        }
+                        Debug.Assert((previous & OperationStatus.CancellationRequested) != 0);
                     }
-                    Debug.Assert((previous & OperationStatus.CancellationRequested) != 0);
                     op.Status = (op.Status & ~(OperationStatus.CancellationRequested | OperationStatus.Executing)) | OperationStatus.Cancelled;
                 }
 

--- a/src/Tmds.LinuxAsync/IOUringAsyncEngine.Queue.cs
+++ b/src/Tmds.LinuxAsync/IOUringAsyncEngine.Queue.cs
@@ -83,11 +83,9 @@ namespace Tmds.LinuxAsync
                     result = op.TryExecuteAsync(triggeredByPoll: false, _thread.ExecutionQueue!,
                                                     (AsyncOperationResult aResult, object? state, int data)
                                                         => ((Queue)state!).HandleAsyncResult(aResult)
-                                                    , state: this, data: 0);
-                    if (result == AsyncExecutionResult.Executing)
-                    {
-                        return;
-                    }
+                                                    , state: this, data: DataForOperation(op));
+                    Debug.Assert(result == AsyncExecutionResult.Executing);
+                    return;
                 }
 
                 _executingOperation = null;
@@ -102,8 +100,6 @@ namespace Tmds.LinuxAsync
 
             private AsyncOperation? CompleteOperationAndGetNext(AsyncOperation op, AsyncExecutionResult result)
             {
-                Debug.Assert(result != AsyncExecutionResult.WaitForPoll); // only used by epoll implementation
-
                 if (result == AsyncExecutionResult.Finished)
                 {
                     op.Status = OperationStatus.Completed;

--- a/src/Tmds.LinuxAsync/IOUringAsyncEngine.Queue.cs
+++ b/src/Tmds.LinuxAsync/IOUringAsyncEngine.Queue.cs
@@ -71,16 +71,10 @@ namespace Tmds.LinuxAsync
             {
                 AsyncOperation? op = _executingOperation!;
 
-                bool cancellationRequested = aResult.Errno == ECANCELED;
-                if (cancellationRequested)
-                {
-                    aResult = AsyncOperationResult.NoResult;
-                }
-
-                AsyncExecutionResult result = op.TryExecute(triggeredByPoll: false, cancellationRequested, asyncOnly: false, _thread.ExecutionQueue,
+                AsyncExecutionResult result = op.HandleAsyncResultAndContinue(aResult, _thread.ExecutionQueue!,
                                                     (AsyncOperationResult aResult, object? state, int data)
                                                         => ((Queue)state!).HandleAsyncResult(aResult)
-                                                    , state: this, data: DataForOperation(op), aResult);
+                                                    , state: this, data: DataForOperation(op));
 
                 if (result == AsyncExecutionResult.Executing)
                 {
@@ -148,10 +142,10 @@ namespace Tmds.LinuxAsync
                         op = QueueGetFirst();
                     }
 
-                    AsyncExecutionResult result = op.TryExecute(triggeredByPoll: false, cancellationRequested: false, asyncOnly: false, _thread.ExecutionQueue,
+                    AsyncExecutionResult result = op.TryExecuteAsync(triggeredByPoll: false, _thread.ExecutionQueue,
                                                         (AsyncOperationResult aResult, object? state, int data)
                                                             => ((Queue)state!).HandleAsyncResult(aResult)
-                                                        , state: this, data: DataForOperation(op), AsyncOperationResult.NoResult);
+                                                        , state: this, data: DataForOperation(op));
 
                     if (result == AsyncExecutionResult.Executing)
                     {

--- a/src/Tmds.LinuxAsync/IOUringAsyncEngine.Queue.cs
+++ b/src/Tmds.LinuxAsync/IOUringAsyncEngine.Queue.cs
@@ -71,14 +71,23 @@ namespace Tmds.LinuxAsync
             {
                 AsyncOperation? op = _executingOperation!;
 
-                AsyncExecutionResult result = op.HandleAsyncResultAndContinue(aResult, _thread.ExecutionQueue!,
+                AsyncExecutionResult result = op.HandleAsyncResult(aResult);
+
+                if (result != AsyncExecutionResult.Finished && op.IsCancellationRequested)
+                {
+                    result = AsyncExecutionResult.Cancelled;
+                }
+
+                if (result == AsyncExecutionResult.Executing || result == AsyncExecutionResult.WaitForPoll)
+                {
+                    result = op.TryExecuteAsync(triggeredByPoll: false, _thread.ExecutionQueue!,
                                                     (AsyncOperationResult aResult, object? state, int data)
                                                         => ((Queue)state!).HandleAsyncResult(aResult)
-                                                    , state: this, data: DataForOperation(op));
-
-                if (result == AsyncExecutionResult.Executing)
-                {
-                    return;                        
+                                                    , state: this, data: 0);
+                    if (result == AsyncExecutionResult.Executing)
+                    {
+                        return;
+                    }
                 }
 
                 _executingOperation = null;


### PR DESCRIPTION
This splits AsyncOperation.TryExecute to make it more easy to understand what it does.

It is replaced with 3 methods:
TryExecuteSync: synchronously attempts to execute the operation
TryExecuteAsync: asynchronously attempts to execute the operation, called on io thread
When TryExecuteAsync uses the AsyncExecutionQueue (that is: AIO/io_uring), then HandleAsyncResultAndContinue needs to be called from callback to handle the result.

cc @antonfirsov @adamsitnik 