### PR TITLE
Make all arguments controlling scheduling enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,24 @@ public enum OutputScheduler
     IOThread,
     ThreadPool
 }
+public enum InputScheduler
+{
+    Inline,
+    ThreadPool
+}
+public enum SocketContinuationScheduler
+{
+    Inline,
+    ThreadPool
+}
 class SocketTransportOptions
 {
   public bool DispatchContinuations { get; set; } = true; // Sets RunContinuationsAsynchronously
   public bool DeferSends { get; set; } = false;           // Sets !PreferSynchronousCompletion for sends
   public bool DeferReceives { get; set; } = false;        // Sets !PreferSynchronousCompletion for receives
-  public bool OutputScheduler { get; set; } = OutputScheduler.IOQueue;
-  public bool ApplicationCodeIsNonBlocking { get; set; } = false;
+  public OutputScheduler OutputScheduler { get; set; } = OutputScheduler.IOQueue;
+  public InputScheduler InputScheduler { get; set; } = InputScheduler.ThreadPool;
+  public SocketContinuationScheduler SocketContinuationScheduler { get; set; } = SocketContinuationScheduler.ThreadPool;
   public bool DontAllocateMemoryForIdleConnections { get; set; } = true;
 }
 ```

--- a/src/Tmds.LinuxAsync.Transport/SocketConnectionListener.cs
+++ b/src/Tmds.LinuxAsync.Transport/SocketConnectionListener.cs
@@ -113,8 +113,8 @@ namespace Tmds.LinuxAsync.Transport
                     }
 
                     var connection = new SocketConnection(acceptSocket, _memoryPool, _schedulers[_schedulerIndex], _trace,
-                        _options.MaxReadBufferSize, _options.MaxWriteBufferSize, _options.DeferSends, _options.DeferReceives, _options.DispatchContinuations,
-                        _options.ApplicationCodeIsNonBlocking, _options.DontAllocateMemoryForIdleConnections, _options.OutputScheduler);
+                        _options.MaxReadBufferSize, _options.MaxWriteBufferSize, _options.DeferSends, _options.DeferReceives, _options.SocketContinuationScheduler,
+                        _options.InputScheduler, _options.DontAllocateMemoryForIdleConnections, _options.OutputScheduler);
 
                     connection.Start();
 

--- a/src/Tmds.LinuxAsync.Transport/SocketTransportOptions.cs
+++ b/src/Tmds.LinuxAsync.Transport/SocketTransportOptions.cs
@@ -14,6 +14,18 @@ namespace Tmds.LinuxAsync.Transport
         ThreadPool
     }
 
+    public enum InputScheduler
+    {
+        Inline,
+        ThreadPool
+    }
+
+    public enum SocketContinuationScheduler
+    {
+        Inline,
+        ThreadPool
+    }
+
     public class SocketTransportOptions
     {
         /// <summary>
@@ -32,11 +44,13 @@ namespace Tmds.LinuxAsync.Transport
         /// </remarks>
         public bool NoDelay { get; set; } = true;
 
-        public bool ApplicationCodeIsNonBlocking { get; set; } = false;
-
         public bool DontAllocateMemoryForIdleConnections { get; set; } = true;
 
         public OutputScheduler OutputScheduler { get; set; } = OutputScheduler.IOQueue;
+
+        public InputScheduler InputScheduler { get; set; } = InputScheduler.ThreadPool;
+
+        public SocketContinuationScheduler SocketContinuationScheduler { get; set; } = SocketContinuationScheduler.ThreadPool;
 
 
         /// <summary>
@@ -53,7 +67,6 @@ namespace Tmds.LinuxAsync.Transport
 
         internal Func<MemoryPool<byte>> MemoryPoolFactory { get; set; } = System.Buffers.SlabMemoryPoolFactory.Create;
 
-        public bool DispatchContinuations { get; set; } = true;
         public bool DeferSends { get; set; } = false;
         public bool DeferReceives { get; set; } = false;
     }

--- a/test/web/ConsoleLineArgumentsParser.cs
+++ b/test/web/ConsoleLineArgumentsParser.cs
@@ -29,8 +29,8 @@ namespace web
         [Option('a', "aio", Required = false, Default = true, HelpText = "Use Linux AIO")]
         public bool? UseAio { get; set; }
 
-        [Option('c', "dispatch-continuations", Required = false, Default = true, HelpText = "Dispatch Continuations")]
-        public bool? DispatchContinuations { get; set; }
+        [Option('c', "socket-scheduler", Required = false, Default = SocketContinuationScheduler.ThreadPool, HelpText = "Inline/ThreadPool")]
+        public SocketContinuationScheduler SocketContinuationScheduler { get; set; }
 
         [Option('s', "defer-sends", Required = false, Default = false, HelpText = "Defer Sends")]
         public bool? DeferSends { get; set; }
@@ -41,11 +41,11 @@ namespace web
         [Option('w', "wait-for-ready", Required = false, Default = true, HelpText = "Don't allocate memory for idle connections")]
         public bool? DontAllocateMemoryForIdleConnections { get; set; }
 
-        [Option('o', "output-writer-scheduler", Required = false, Default = OutputScheduler.IOQueue, HelpText = "IOQueue/Inline/IOThread/ThreadPool")]
+        [Option('o', "output-scheduler", Required = false, Default = OutputScheduler.IOQueue, HelpText = "IOQueue/Inline/IOThread/ThreadPool")]
         public OutputScheduler OutputScheduler { get; set; }
 
-        [Option('i', "inline-app", Required = false, Default = false, HelpText = "Application code is non blocking")]
-        public bool? ApplicationCodeIsNonBlocking { get; set; }
+        [Option('i', "input-scheduler", Required = false, Default = InputScheduler.ThreadPool, HelpText = "Inline/ThreadPool")]
+        public InputScheduler InputScheduler { get; set; }
     }
 
     public static class ConsoleLineArgumentsParser

--- a/test/web/Program.cs
+++ b/test/web/Program.cs
@@ -42,7 +42,7 @@ namespace web
                                 serviceCollection.AddIoUringTransport(options =>
                                 {
                                     options.ThreadCount = commandLineOptions.ThreadCount;
-                                    options.ApplicationSchedulingMode = commandLineOptions.ApplicationCodeIsNonBlocking.Value ?
+                                    options.ApplicationSchedulingMode = commandLineOptions.InputScheduler == InputScheduler.Inline ?
                                         PipeScheduler.Inline : PipeScheduler.ThreadPool;
                                 }));
                             break;
@@ -51,7 +51,7 @@ namespace web
                             {
                                 options.ThreadCount = commandLineOptions.ThreadCount;
                                 options.DeferSend = commandLineOptions.DeferSends.Value;
-                                options.ApplicationSchedulingMode= commandLineOptions.ApplicationCodeIsNonBlocking.Value ?
+                                options.ApplicationSchedulingMode= commandLineOptions.InputScheduler == InputScheduler.Inline ?
                                     PipeScheduler.Inline : PipeScheduler.ThreadPool;
                             });
                             break;
@@ -64,12 +64,12 @@ namespace web
                         default:
                             webBuilder.UseLinuxAsyncSockets(options =>
                                 {
-                                    options.DispatchContinuations = commandLineOptions.DispatchContinuations.Value;
                                     options.DeferSends = commandLineOptions.DeferSends.Value;
                                     options.DeferReceives = commandLineOptions.DeferReceives.Value;
                                     options.DontAllocateMemoryForIdleConnections = commandLineOptions.DontAllocateMemoryForIdleConnections.Value;
                                     options.OutputScheduler = commandLineOptions.OutputScheduler;
-                                    options.ApplicationCodeIsNonBlocking = commandLineOptions.ApplicationCodeIsNonBlocking.Value;
+                                    options.InputScheduler = commandLineOptions.InputScheduler;
+                                    options.SocketContinuationScheduler = commandLineOptions.SocketContinuationScheduler;
                                 }
                             );
                             break;
@@ -79,7 +79,7 @@ namespace web
 
         private static AsyncEngine CreateAsyncEngine(CommandLineOptions commandLineOptions)
         {
-            bool batchOnIOThread = !commandLineOptions.DispatchContinuations.Value ||
+            bool batchOnIOThread = commandLineOptions.SocketContinuationScheduler == SocketContinuationScheduler.Inline ||
                                           commandLineOptions.OutputScheduler == OutputScheduler.IOThread;
             switch (commandLineOptions.SocketEngine)
             {


### PR DESCRIPTION
This is for UX mostly.
Any arg that is a scheduler is now an enum
so `-c false` is `-c inline`
and `-i false` is `-i threadpool`.

cc @antonfirsov @adamsitnik 