### PR TITLE
Remove AsyncOperation.IsReadNotWrite

### DIFF
--- a/src/Tmds.LinuxAsync/AsyncAcceptOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncAcceptOperation.cs
@@ -95,7 +95,7 @@ namespace Tmds.LinuxAsync
 
             // Reset state.
             Status = OperationStatus.None;
-            CurrentAsyncContext = null;
+            CurrentQueue = null;
 
             // Complete.
             _saea.Complete(completionStatus);
@@ -115,8 +115,6 @@ namespace Tmds.LinuxAsync
         {
             Socket = socket;
         }
-
-        public override bool IsReadNotWrite => true;
 
         public override bool TryExecuteSync()
         {

--- a/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncConnectOperation.cs
@@ -96,7 +96,7 @@ namespace Tmds.LinuxAsync
 
             // Reset state.
             Status = OperationStatus.None;
-            CurrentAsyncContext = null;
+            CurrentQueue = null;
 
             // Complete.
             _saea.Complete(completionStatus);
@@ -123,9 +123,6 @@ namespace Tmds.LinuxAsync
                 throw new NotSupportedException();
             }
         }
-
-        public override bool IsReadNotWrite => false;
-
         public override bool TryExecuteSync()
         {
             Socket socket = Socket!;

--- a/src/Tmds.LinuxAsync/AsyncContext.cs
+++ b/src/Tmds.LinuxAsync/AsyncContext.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading;
 using System.IO.Pipelines;
+using System.Diagnostics;
 
 namespace Tmds.LinuxAsync
 {
@@ -11,27 +12,41 @@ namespace Tmds.LinuxAsync
         // Cancels async operations and disposes the context.
         public abstract void Dispose();
 
-        // Execute an async operation.
-        public abstract bool ExecuteAsync(AsyncOperation operation, bool preferSync = true);
+        public bool ExecuteReadAsync(AsyncOperation operation, bool preferSync = true)
+        {
+            return ExecuteAsync(operation, preferSync, _readQueue!);
+        }
 
-        // Cancel AsyncOperation.
-        internal abstract void TryCancelAndComplete(AsyncOperation asyncOperation, OperationStatus status);
+        public bool ExecuteWriteAsync(AsyncOperation operation, bool preferSync = true)
+        {
+            return ExecuteAsync(operation, preferSync, _writeQueue!);
+        }
 
-        // operation caching
-        private AsyncOperation? _cachedReadOperation;
-        private AsyncOperation? _cachedWriteOperation;
+        private static bool ExecuteAsync(AsyncOperation operation, bool preferSync, AsyncOperationQueueBase queue)
+        {
+            try
+            {
+                operation.CurrentQueue = queue;
+
+                return queue.ExecuteAsync(operation, preferSync);
+            }
+            catch
+            {
+                operation.Status = OperationStatus.CancelledSync;
+                operation.Complete();
+
+                throw;
+            }
+        }
+
+        protected AsyncOperationQueueBase? _readQueue;
+        protected AsyncOperationQueueBase? _writeQueue;
 
         public T RentReadOperation<T>() where T : AsyncOperation, new()
-            => (T?)Interlocked.Exchange(ref _cachedReadOperation, null) ?? new T();
+            => _readQueue!.RentOperation<T>();
 
         public T RentWriteOperation<T>() where T : AsyncOperation, new()
-            => (T?)Interlocked.Exchange(ref _cachedWriteOperation, null) ?? new T();
-
-        public void ReturnReadOperation(AsyncOperation state)
-            => Volatile.Write(ref _cachedReadOperation, state);
-
-        public void ReturnWriteOperation(AsyncOperation state)
-            => Volatile.Write(ref _cachedWriteOperation, state);
+            => _writeQueue!.RentOperation<T>();
 
         public abstract PipeScheduler? IOThreadScheduler { get; }
     }

--- a/src/Tmds.LinuxAsync/AsyncReceiveOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncReceiveOperation.cs
@@ -96,7 +96,7 @@ namespace Tmds.LinuxAsync
 
             // Reset state.
             Status = OperationStatus.None;
-            CurrentAsyncContext = null;
+            CurrentQueue = null;
 
             // Complete.
             _saea.Complete(completionStatus);
@@ -123,9 +123,6 @@ namespace Tmds.LinuxAsync
             Socket = socket;
             MemoryBuffer = memory;
         }
-
-        public override bool IsReadNotWrite => true;
-
         public override bool TryExecuteSync()
         {
             Socket socket = Socket!;

--- a/src/Tmds.LinuxAsync/AsyncSendOperation.cs
+++ b/src/Tmds.LinuxAsync/AsyncSendOperation.cs
@@ -96,7 +96,7 @@ namespace Tmds.LinuxAsync
 
             // Reset state.
             Status = OperationStatus.None;
-            CurrentAsyncContext = null;
+            CurrentQueue = null;
 
             // Complete.
             _saea.Complete(completionStatus);
@@ -122,9 +122,6 @@ namespace Tmds.LinuxAsync
             MemoryBuffer = memory;
             BufferList = bufferList;
         }
-
-        public override bool IsReadNotWrite => false;
-
         public override bool TryExecuteSync()
         {
             IList<ArraySegment<byte>>? bufferList = BufferList;

--- a/src/Tmds.LinuxAsync/EPollAsyncEngine.Queue.cs
+++ b/src/Tmds.LinuxAsync/EPollAsyncEngine.Queue.cs
@@ -175,7 +175,7 @@ namespace Tmds.LinuxAsync
                 } while (op != null);
             }
 
-            public bool ExecuteAsync(AsyncOperation operation, bool preferSync)
+            public override bool ExecuteAsync(AsyncOperation operation, bool preferSync)
             {
                 int? eventCounterSnapshot = null;
 
@@ -223,7 +223,10 @@ namespace Tmds.LinuxAsync
                 return true;
             }
 
-            public void TryCancelAndComplete(AsyncOperation operation, OperationStatus flags, bool wait = false)
+            public override void TryCancelAndComplete(AsyncOperation operation, OperationStatus flags)
+                => TryCancelAndComplete(operation, flags, wait: false);
+
+            private void TryCancelAndComplete(AsyncOperation operation, OperationStatus flags, bool wait)
             {
                 OperationStatus previous = OperationStatus.Queued;
                 do

--- a/src/Tmds.LinuxAsync/IOUringAsyncEngine.IOUringAsyncContext.cs
+++ b/src/Tmds.LinuxAsync/IOUringAsyncEngine.IOUringAsyncContext.cs
@@ -13,11 +13,8 @@ namespace Tmds.LinuxAsync
         sealed class IOUringAsyncContext : AsyncContext
         {
             private readonly IOUringThread _iouring;
-            private readonly Queue _writeQueue;
-            private readonly Queue _readQueue;
             private SafeHandle? _handle;
             private int _fd;
-            private bool _setToNonBlocking;
 
             public int Key => _fd;
 
@@ -25,26 +22,30 @@ namespace Tmds.LinuxAsync
 
             public override PipeScheduler? IOThreadScheduler => _iouring;
 
+            private Queue ReadQueue => (Queue)_readQueue!;
+            private Queue WriteQueue => (Queue)_writeQueue!;
+
             public IOUringAsyncContext(IOUringThread thread, SafeHandle handle)
             {
                 _iouring = thread;
-                _writeQueue = new Queue(thread, this);
-                _readQueue = new Queue(thread, this);
+                _writeQueue = new Queue(thread, this, readNotWrite: false);
+                _readQueue = new Queue(thread, this, readNotWrite: true);
                 bool success = false;
                 handle.DangerousAddRef(ref success);
                 _fd = handle.DangerousGetHandle().ToInt32();
                 _handle = handle;
+                SocketPal.SetNonBlocking(handle);
             }
 
             public override void Dispose()
             {
-                bool dispose = _readQueue.Dispose();
+                bool dispose = ReadQueue.Dispose();
                 if (!dispose)
                 {
                     // Already disposed.
                     return;
                 }
-                _writeQueue.Dispose();
+                WriteQueue.Dispose();
                 _iouring.RemoveContext(Key);
 
                 if (_handle != null)
@@ -52,60 +53,6 @@ namespace Tmds.LinuxAsync
                     _handle.DangerousRelease();
                     _fd = -1;
                     _handle = null;
-                }
-            }
-
-            public override bool ExecuteAsync(AsyncOperation operation, bool preferSync)
-            {
-                EnsureNonBlocking();
-
-                try
-                {
-                    operation.CurrentAsyncContext = this;
-
-                    if (operation.IsReadNotWrite)
-                    {
-                        return _readQueue.ExecuteAsync(operation, preferSync);
-                    }
-                    else
-                    {
-                        return _writeQueue.ExecuteAsync(operation, preferSync);
-                    }
-                }
-                catch
-                {
-                    operation.Status = OperationStatus.CancelledSync;
-                    operation.Complete();
-
-                    throw;
-                }
-            }
-
-            private void EnsureNonBlocking()
-            {
-                SafeHandle? handle = _handle;
-                if (handle == null)
-                {
-                    // We've been disposed.
-                    return;
-                }
-
-                if (!_setToNonBlocking)
-                {
-                    SocketPal.SetNonBlocking(handle);
-                    _setToNonBlocking = true;
-                }
-            }
-
-            internal override void TryCancelAndComplete(AsyncOperation operation, OperationStatus status)
-            {
-                if (operation.IsReadNotWrite)
-                {
-                    _readQueue.TryCancelAndComplete(operation, status);
-                }
-                else
-                {
-                    _writeQueue.TryCancelAndComplete(operation, status);
                 }
             }
         }

--- a/src/Tmds.LinuxAsync/IOUringAsyncEngine.Queue.cs
+++ b/src/Tmds.LinuxAsync/IOUringAsyncEngine.Queue.cs
@@ -18,7 +18,7 @@ namespace Tmds.LinuxAsync
             {
                 _thread = thread;
                 _context = context;
-                // Needed to distinguish distinguish on-going read/write operations on this handle.
+                // This is used to distinguish on-going read from write when cancelling.
                 _dataForOperation = readNotWrite ? POLLIN : POLLOUT;
             }
 

--- a/src/Tmds.LinuxAsync/Socket.cs
+++ b/src/Tmds.LinuxAsync/Socket.cs
@@ -59,7 +59,10 @@ namespace Tmds.LinuxAsync
         // Dispose.
         private void Dispose(bool disposing)
         {
-            AsyncContext?.Dispose();
+            if (_asyncContext != null)
+            {
+                _asyncContext.Dispose();
+            }
             _innerSocket?.Dispose();
         }
 
@@ -91,6 +94,7 @@ namespace Tmds.LinuxAsync
             var op = e.StartConnectOperation(this);
             return AsyncContext.ExecuteWriteAsync(op, e.PreferSynchronousCompletion);
         }
+
         public ValueTask<int> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
This eliminates the virtual IsReadNotWrite method.

I don't expect it to affect traces in a measurable way.

cc @antonfirsov @adamsitnik 