### PR TITLE
Benchmark System.Net.Sockets.Socket

### DIFF
--- a/test/web/ISocketHandler.cs
+++ b/test/web/ISocketHandler.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using SocketAsyncEventArgs = Tmds.LinuxAsync.SocketAsyncEventArgs;
+
+namespace web
+{
+    public interface ISocketHandler<TSocket, TSocketEventArgs> 
+        where TSocket : IDisposable
+        where TSocketEventArgs : IDisposable
+    {
+        TSocket CreateListenerSocket(IPEndPoint endPoint, int backlog);
+        Task<TSocket> AcceptAsync(TSocket socket);
+        TSocketEventArgs CreateSocketEventArgs(bool preferSynchronousCompletion, bool runContinuationsAsynchronously, EventHandler<TSocketEventArgs> completed);
+
+        void SetBuffer(TSocketEventArgs args, byte[] buffer, int offset, int count);
+
+        bool SendAsync(TSocket socket, TSocketEventArgs args);
+
+        bool ReceiveAsync(TSocket socket, TSocketEventArgs args);
+
+        (int bytesTransferred, SocketError error) GetStatus(TSocketEventArgs args);
+    }
+
+    struct SystemNetSocketHandler : ISocketHandler<System.Net.Sockets.Socket, System.Net.Sockets.SocketAsyncEventArgs>
+    {
+        public Socket CreateListenerSocket(IPEndPoint endPoint, int backlog)
+        {
+            var socket = new System.Net.Sockets.Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            socket.Bind(endPoint);
+            socket.Listen(backlog);
+            return socket;
+        }
+
+        public Task<Socket> AcceptAsync(Socket socket) => socket.AcceptAsync();
+
+        public System.Net.Sockets.SocketAsyncEventArgs CreateSocketEventArgs(bool preferSynchronousCompletion, bool runContinuationsAsynchronously,
+            EventHandler<System.Net.Sockets.SocketAsyncEventArgs> completed)
+        {
+            var result = new System.Net.Sockets.SocketAsyncEventArgs();
+            result.Completed += completed;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetBuffer(System.Net.Sockets.SocketAsyncEventArgs args, byte[] buffer, int offset, int count) 
+            => args.SetBuffer(buffer, offset, count);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool SendAsync(Socket socket, System.Net.Sockets.SocketAsyncEventArgs args) 
+            => socket.SendAsync(args);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ReceiveAsync(Socket socket, System.Net.Sockets.SocketAsyncEventArgs args) =>
+            socket.ReceiveAsync(args);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (int bytesTransferred, SocketError error) GetStatus(System.Net.Sockets.SocketAsyncEventArgs args)
+        {
+            return (args.BytesTransferred, args.SocketError);
+        }
+    }
+
+    struct TmdsSocketHandler : ISocketHandler<Tmds.LinuxAsync.Socket, Tmds.LinuxAsync.SocketAsyncEventArgs>
+    {
+        public Tmds.LinuxAsync.Socket CreateListenerSocket(IPEndPoint endPoint, int backlog)
+        {
+            var socket = new Tmds.LinuxAsync.Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            socket.Bind(endPoint);
+            socket.Listen(backlog);
+            return socket;
+        }
+
+        public Task<Tmds.LinuxAsync.Socket> AcceptAsync(Tmds.LinuxAsync.Socket socket) => socket.AcceptAsync();
+
+        public SocketAsyncEventArgs CreateSocketEventArgs(bool preferSynchronousCompletion, bool runContinuationsAsynchronously,
+            EventHandler<SocketAsyncEventArgs> completed)
+        {
+            var result = new Tmds.LinuxAsync.SocketAsyncEventArgs()
+            {
+                PreferSynchronousCompletion = preferSynchronousCompletion,
+                RunContinuationsAsynchronously = runContinuationsAsynchronously
+            };
+            result.Completed += completed;
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void SetBuffer(SocketAsyncEventArgs args, byte[] buffer, int offset, int count) 
+            => args.SetBuffer(buffer, offset, count);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool SendAsync(Tmds.LinuxAsync.Socket socket, SocketAsyncEventArgs args)
+            => socket.SendAsync(args);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool ReceiveAsync(Tmds.LinuxAsync.Socket socket, SocketAsyncEventArgs args)
+            => socket.ReceiveAsync(args);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public (int bytesTransferred, SocketError error) GetStatus(SocketAsyncEventArgs args)
+        {
+            return (args.BytesTransferred, args.SocketError);
+        }
+    }
+}

--- a/test/web/Program.cs
+++ b/test/web/Program.cs
@@ -28,13 +28,13 @@ namespace web
                     if (options.SocketEngine == SocketEngineType.DefaultTransport)
                     {
                         var handler = new SystemNetSocketHandler();
-                        var host = new RawSocketHost<Socket, SocketAsyncEventArgs>(options, args, handler);
+                        var host = new RawSocketHost<Socket, SocketAsyncEventArgs, SystemNetSocketHandler>(options, args, handler);
                         host.Run();
                     }
                     else
                     {
                         var handler = new TmdsSocketHandler();
-                        var host = new RawSocketHost<Tmds.LinuxAsync.Socket, Tmds.LinuxAsync.SocketAsyncEventArgs>(options, args, handler);
+                        var host = new RawSocketHost<Tmds.LinuxAsync.Socket, Tmds.LinuxAsync.SocketAsyncEventArgs, TmdsSocketHandler>(options, args, handler);
                         host.Run();
                     }
                 }

--- a/test/web/Program.cs
+++ b/test/web/Program.cs
@@ -5,6 +5,8 @@ using Tmds.LinuxAsync;
 using IoUring.Transport;
 using System.IO.Pipelines;
 using Tmds.LinuxAsync.Transport;
+using Socket = System.Net.Sockets.Socket;
+using SocketAsyncEventArgs = System.Net.Sockets.SocketAsyncEventArgs;
 #if RELEASE
 using Microsoft.Extensions.Logging;
 #endif
@@ -23,8 +25,18 @@ namespace web
 
                 if (options.RawSocket)
                 {
-                    RawSocketHost host = new RawSocketHost(options, args);
-                    host.Run();
+                    if (options.SocketEngine == SocketEngineType.DefaultTransport)
+                    {
+                        var handler = new SystemNetSocketHandler();
+                        var host = new RawSocketHost<Socket, SocketAsyncEventArgs>(options, args, handler);
+                        host.Run();
+                    }
+                    else
+                    {
+                        var handler = new TmdsSocketHandler();
+                        var host = new RawSocketHost<Tmds.LinuxAsync.Socket, Tmds.LinuxAsync.SocketAsyncEventArgs>(options, args, handler);
+                        host.Run();
+                    }
                 }
                 else
                 {

--- a/test/web/RawSocketHost.ClientConnectionHandler.cs
+++ b/test/web/RawSocketHost.ClientConnectionHandler.cs
@@ -6,11 +6,11 @@ using SocketAsyncEventArgs = Tmds.LinuxAsync.SocketAsyncEventArgs;
 
 namespace web
 {
-    public partial class RawSocketHost<TSocket, TSocketEventArgs>
+    public partial class RawSocketHost<TSocket, TSocketEventArgs, TSocketHandler>
     {
         private class ClientConnectionHandler
         {
-            private readonly ISocketHandler<TSocket, TSocketEventArgs> _socketHandler;
+            private readonly TSocketHandler _socketHandler;
             private readonly TSocket _socket;
             private readonly byte[] _sendBuffer = Encoding.ASCII.GetBytes(Response);
             private readonly byte[] _receiveBuffer = new byte[BufferSize];
@@ -19,7 +19,7 @@ namespace web
             private readonly TSocketEventArgs _receiveArgs;
             private readonly TSocketEventArgs _sendArgs;
 
-            public ClientConnectionHandler(TSocket socket, ISocketHandler<TSocket, TSocketEventArgs> socketHandler, 
+            public ClientConnectionHandler(TSocket socket, TSocketHandler socketHandler, 
                 bool deferSends, bool deferReceives, bool runContinuationsAsynchronously)
             {
                 _socket = socket;

--- a/test/web/RawSocketHost.ClientConnectionHandler.cs
+++ b/test/web/RawSocketHost.ClientConnectionHandler.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Net.Sockets;
+using System.Text;
+using Socket = Tmds.LinuxAsync.Socket;
+using SocketAsyncEventArgs = Tmds.LinuxAsync.SocketAsyncEventArgs;
+
+namespace web
+{
+    public partial class RawSocketHost<TSocket, TSocketEventArgs>
+    {
+        private class ClientConnectionHandler
+        {
+            private readonly ISocketHandler<TSocket, TSocketEventArgs> _socketHandler;
+            private readonly TSocket _socket;
+            private readonly byte[] _sendBuffer = Encoding.ASCII.GetBytes(Response);
+            private readonly byte[] _receiveBuffer = new byte[BufferSize];
+            private int _bytesReceieved;
+
+            private readonly TSocketEventArgs _receiveArgs;
+            private readonly TSocketEventArgs _sendArgs;
+
+            public ClientConnectionHandler(TSocket socket, ISocketHandler<TSocket, TSocketEventArgs> socketHandler, 
+                bool deferSends, bool deferReceives, bool runContinuationsAsynchronously)
+            {
+                _socket = socket;
+                _socketHandler = socketHandler;
+
+                _sendArgs = socketHandler.CreateSocketEventArgs(
+                    !deferSends, 
+                    runContinuationsAsynchronously,
+                    (s, a) => RequestReceive());
+                socketHandler.SetBuffer(_sendArgs, _sendBuffer, 0, _sendBuffer.Length);
+                
+                _receiveArgs = socketHandler.CreateSocketEventArgs(
+                    !deferReceives, 
+                    runContinuationsAsynchronously,
+                    (s, a) => HandleReceive());
+            }
+            
+            public void HandleClient()
+            {
+                RequestReceive();
+            }
+
+            private void RequestReceive()
+            {
+                try
+                {
+                    _socketHandler.SetBuffer(_receiveArgs, 
+                        _receiveBuffer, 
+                        _bytesReceieved,
+                        _receiveBuffer.Length - _bytesReceieved);
+
+                    if (!_socketHandler.ReceiveAsync(_socket, _receiveArgs))
+                    {
+                        HandleReceive();
+                    }
+                }
+                catch
+                {
+                    Cleanup();
+                }
+            }
+
+            private void HandleReceive()
+            {
+                (int byteCount, SocketError error) = _socketHandler.GetStatus(_receiveArgs);
+
+                if (error == SocketError.Success && byteCount != 0)
+                {
+                    _bytesReceieved += byteCount;
+                    if (RequestComplete())
+                    {
+                        _bytesReceieved = 0;
+                        SendResponse();
+                    }
+                    else
+                    {
+                        RequestReceive();
+                    }
+                }
+                else
+                {
+                    Cleanup();
+                }
+            }
+            
+            private bool RequestComplete()
+            {
+                return _bytesReceieved > 4 && _receiveBuffer.AsSpan(_bytesReceieved - 4, 4).SequenceEqual(RequestEnd);
+            }
+
+            private void SendResponse()
+            {
+                try
+                {
+                    if (!_socketHandler.SendAsync(_socket, _sendArgs))
+                    {
+                        RequestReceive();
+                    }
+                }
+                catch
+                {
+                    Cleanup();
+                }
+            }
+
+            private void Cleanup()
+            {
+                _receiveArgs.Dispose();
+                _sendArgs.Dispose();
+                _socket.Dispose();
+            }
+        }
+    }
+}

--- a/test/web/RawSocketHost.cs
+++ b/test/web/RawSocketHost.cs
@@ -1,19 +1,20 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Tmds.LinuxAsync.Transport;
 
 using Socket = Tmds.LinuxAsync.Socket;
-using SocketAsyncEventArgs = Tmds.LinuxAsync.SocketAsyncEventArgs;
 
 namespace web
 {
-    public class RawSocketHost
+    public partial class RawSocketHost<TSocket, TSocketEventArgs>
+        where TSocket : IDisposable
+        where TSocketEventArgs : IDisposable
     {
+        private readonly ISocketHandler<TSocket, TSocketEventArgs> _socketHandler;
         private const int BufferSize = 512;
         private const string Response =
             "HTTP/1.1 200 OK\r\nDate: Tue, 31 Mar 2020 14:49:06 GMT\r\nContent-Type: application/json\r\nServer: Kestrel\r\nContent-Length: 27\r\n\r\n{\"message\":\"Hello, World!\"}";
@@ -25,11 +26,12 @@ namespace web
 
         private IPEndPoint _serverEndpoint;
 
-        public RawSocketHost(CommandLineOptions options, string[] args)
+        public RawSocketHost(CommandLineOptions options, string[] args, ISocketHandler<TSocket, TSocketEventArgs> socketHandler)
         {
             _options = options;
             _args = args;
-            
+            _socketHandler = socketHandler;
+
             ConfigurationBuilder bld = new ConfigurationBuilder();
             bld.AddCommandLine(_args);
             var cfg = bld.Build();
@@ -49,9 +51,7 @@ namespace web
 
         public async Task RunAsync()
         {
-            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            listener.Bind(_serverEndpoint);
-            listener.Listen(1024);
+            using TSocket listener = _socketHandler.CreateListenerSocket(_serverEndpoint, 1024);
             Console.WriteLine($"Raw server listening on {_serverEndpoint}");
 
             bool deferSends = _options.DeferSends == true;
@@ -61,117 +61,15 @@ namespace web
 
             while (true)
             {
-                Socket handlerSocket = await listener.AcceptAsync();
+                TSocket handlerSocket = await _socketHandler.AcceptAsync(listener);
                 
                 ClientConnectionHandler clientHandler = 
-                    new ClientConnectionHandler(handlerSocket, deferSends, deferReceives, runContinuationsAsynchronously);
+                    new ClientConnectionHandler(handlerSocket, _socketHandler, deferSends, deferReceives, runContinuationsAsynchronously);
 
                 clientHandler.HandleClient();
             }
         }
 
-        class ClientConnectionHandler
-        {
-            private readonly Socket _socket;
-            private readonly byte[] _sendBuffer = Encoding.ASCII.GetBytes(Response);
-            private readonly byte[] _receiveBuffer = new byte[BufferSize];
-            private int _bytesReceieved;
-
-            private readonly SocketAsyncEventArgs _receiveArgs;
-            private readonly SocketAsyncEventArgs _sendArgs;
-            
-            public ClientConnectionHandler(Socket socket, bool deferSends, bool deferReceives, bool runContinuationsAsynchronously)
-            {
-                _socket = socket;
-                _sendArgs = new SocketAsyncEventArgs()
-                {
-                    PreferSynchronousCompletion = !deferSends,
-                    RunContinuationsAsynchronously = runContinuationsAsynchronously
-                };
-                _sendArgs.SetBuffer(_sendBuffer);
-                _sendArgs.Completed += (s, a) => RequestReceive();
-
-                _receiveArgs = new SocketAsyncEventArgs()
-                {
-                    PreferSynchronousCompletion = !deferReceives,
-                    RunContinuationsAsynchronously = runContinuationsAsynchronously
-                };
-                
-                _receiveArgs.Completed += (s,a) => HandleReceive();
-            }
-            
-            public void HandleClient()
-            {
-                RequestReceive();
-            }
-
-            private void RequestReceive()
-            {
-                try
-                {
-                    _receiveArgs.SetBuffer(_receiveBuffer, _bytesReceieved, _receiveBuffer.Length - _bytesReceieved);
-                    
-                    if (!_socket.ReceiveAsync(_receiveArgs))
-                    {
-                        HandleReceive();
-                    }
-                }
-                catch
-                {
-                    Cleanup();
-                }
-            }
-
-            private void HandleReceive()
-            {
-                int byteCount = _receiveArgs.BytesTransferred;    
-                SocketError error = _receiveArgs.SocketError;
-
-                if (error == SocketError.Success && byteCount != 0)
-                {
-                    _bytesReceieved += byteCount;
-                    if (RequestComplete())
-                    {
-                        _bytesReceieved = 0;
-                        SendResponse();
-                    }
-                    else
-                    {
-                        RequestReceive();
-                    }
-                }
-                else
-                {
-                    Cleanup();
-                }
-            }
-            
-            private bool RequestComplete()
-            {
-                return _bytesReceieved > 4 && _receiveBuffer.AsSpan(_bytesReceieved - 4, 4).SequenceEqual(RequestEnd);
-            }
-
-            private void SendResponse()
-            {
-                try
-                {
-                    if (!_socket.SendAsync(_sendArgs))
-                    {
-                        RequestReceive();
-                    }
-                }
-                catch
-                {
-                    Cleanup();
-                }
-            }
-
-            private void Cleanup()
-            {
-                _receiveArgs.Dispose();
-                _sendArgs.Dispose();
-                _socket.Dispose();
-            }
-        }
+        
     }
 }

--- a/test/web/RawSocketHost.cs
+++ b/test/web/RawSocketHost.cs
@@ -10,11 +10,12 @@ using Socket = Tmds.LinuxAsync.Socket;
 
 namespace web
 {
-    public partial class RawSocketHost<TSocket, TSocketEventArgs>
+    public partial class RawSocketHost<TSocket, TSocketEventArgs, TSocketHandler>
         where TSocket : IDisposable
         where TSocketEventArgs : IDisposable
+        where TSocketHandler : struct, ISocketHandler<TSocket, TSocketEventArgs>
     {
-        private readonly ISocketHandler<TSocket, TSocketEventArgs> _socketHandler;
+        private readonly TSocketHandler _socketHandler;
         private const int BufferSize = 512;
         private const string Response =
             "HTTP/1.1 200 OK\r\nDate: Tue, 31 Mar 2020 14:49:06 GMT\r\nContent-Type: application/json\r\nServer: Kestrel\r\nContent-Length: 27\r\n\r\n{\"message\":\"Hello, World!\"}";
@@ -26,7 +27,7 @@ namespace web
 
         private IPEndPoint _serverEndpoint;
 
-        public RawSocketHost(CommandLineOptions options, string[] args, ISocketHandler<TSocket, TSocketEventArgs> socketHandler)
+        public RawSocketHost(CommandLineOptions options, string[] args, TSocketHandler socketHandler)
         {
             _options = options;
             _args = args;


### PR DESCRIPTION
Adds an abstraction based on generic constraints to switch between `System.Net.Sockets` and `Tmds.LinuxAsync`. This construct enables devirtualization, so there should be no visible overhead.

Benchmark execution is WIP.